### PR TITLE
xHTML → HTML5

### DIFF
--- a/makeblog/templates/article.html
+++ b/makeblog/templates/article.html
@@ -3,7 +3,7 @@
 {% block title %}{{ super() }} - {{ post.title }}{% endblock %}
 {% block head %}
 {{ super() }}
-<link rel="canonical" href="{{ post.permalink }}/" />
+<link rel="canonical" href="{{ post.permalink }}/">
 {% endblock %}
 {% block content %}
 {% include 'pre_article.html' ignore missing %}

--- a/makeblog/templates/author.html
+++ b/makeblog/templates/author.html
@@ -27,7 +27,7 @@ Namen {{ author.name }}.</p>
 		<th>Letzte 10 Artikel</th>
 		<td>
 			{% for post in author.posts[-10:] %}
-			{{ post.date }} - {{ post.title }}<br/>
+			{{ post.date }} - {{ post.title }}<br>
 			{% endfor %}
 		</td>
 </table>

--- a/makeblog/templates/post.html
+++ b/makeblog/templates/post.html
@@ -6,7 +6,7 @@
 {% endfor %}
 </div>
 {{ post.content }}
-<hr/>
+<hr>
 {% endmacro %}
 {% macro postlistrenderer(posts) %}
 <ul>

--- a/makeblog/templates/site.html
+++ b/makeblog/templates/site.html
@@ -1,18 +1,16 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" 
-    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">    
+<!doctype html>
+<html>    
 <head>
 {% block head %}
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+<meta charset="utf-8">
 <title>{% block title %}{{ blog.config['blog']['name'] }}{% endblock %}</title>
-<link rel="alternate" type="application/atom+xml" title="Atom 1.0"
-href="/feed.atom" />
+<link rel="alternate" type="application/atom+xml" title="Atom 1.0" href="/feed.atom">
 {% endblock %}
 </head>
 <body>
 {% block body %}
 <h1><a href="{{ blog.config['blog']['url'] }}">{{ blog.config['blog']['name'] }}</a></h1>
-<h2 class='alt'>{{ blog.config['blog']['description'] }}</h2>
+<h2 class="alt">{{ blog.config['blog']['description'] }}</h2>
 {% block content %}
 {% endblock %}
 {% endblock body %}


### PR DESCRIPTION
Updated the templates from xHTML to HTML5. This should be the default because HTML5 is the successor of HTML4 and xHTML.
