### PR TITLE
Fixed error if categories is null

### DIFF
--- a/makeblog/post.py
+++ b/makeblog/post.py
@@ -54,7 +54,8 @@ class Post(object):
         if 'permalink' in header:
             self.permalink = header['permalink']
         self.guid = header['guid']
-        self.categories = [category.strip() for category in
+        if header['categories']:
+            self.categories = [category.strip() for category in
                            header['categories'].split(',')]
         self.date = timezone(self.blog.config['blog']['timezone']).\
             localize(datetime.strptime(header['date'],


### PR DESCRIPTION
If an article got no categories (==null), makeblog shouldn't raise an error. Fixed this.
